### PR TITLE
Padding bytes may not be zero.

### DIFF
--- a/snxconnect.py
+++ b/snxconnect.py
@@ -380,7 +380,7 @@ class PW_Encode (object) :
         if self.testing :
             r.append (b'\1' * n)
         else :
-            r.append (os.urandom (n))
+            r.append (bytes([x % 255 + 1 for x in os.urandom (n)]))
         r.append (b'\x02')
         r.append (b'\x00')
         return b''.join (reversed (r))


### PR DESCRIPTION
Fixes #18

See pkcs1pad2 in JS_RSA.js:
...
  while(n > 2) { // random non-zero pad
    x[0] = 0;
    while(x[0] == 0) rng.nextBytes(x);
    ba[--n] = x[0];
  }
...