### PR TITLE
Update dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup \
     , platforms        = 'Linux'
     , url              = "https://github.com/schlatterbeck/snxvpn"
     , scripts          = ['snxconnect']
-    , install_requires = [ 'bs4', 'pycrypto', 'lxml' ]
+    , install_requires = [ 'bs4', 'pycryptodomex', 'lxml' ]
     , classifiers      = \
         [ 'Development Status :: 3 - Alpha'
         , 'License :: OSI Approved :: ' + license


### PR DESCRIPTION
pycrypto is depreceated

```
  ERROR: Failed building wheel for pycrypto
  Running setup.py clean for pycrypto                                                                                                                                                                                                       
Failed to build pycrypto
ERROR: Could not build wheels for pycrypto, which is required to install pyproject.toml-based projects
```
